### PR TITLE
Links should no longer overlap on the mobile menu

### DIFF
--- a/src/components/Contact/Contact.jsx
+++ b/src/components/Contact/Contact.jsx
@@ -1,5 +1,6 @@
 import "./Contact.scss";
 import Button from "../Button/Button";
+import HighlightLink from "../HighlightLink/HighlightLink";
 import { ContainerWrapper, MotionWrapper } from "../../wrapper";
 
 import { AiFillMail, AiFillLinkedin, AiFillGithub } from "react-icons/ai";
@@ -9,9 +10,9 @@ function Contact() {
     <div className="contact">
       <h2>
         Get in touch, drop me an{" "}
-        <a className="contact-link" href="mailto:kirsten.malcaba@outlook.com">
+        <HighlightLink href="mailto:kirsten.malcaba@outlook.com">
           email
-        </a>
+        </HighlightLink>
         ! 💌
       </h2>
       <div className="contact-cards">

--- a/src/components/Contact/Contact.scss
+++ b/src/components/Contact/Contact.scss
@@ -26,51 +26,8 @@
     }
   }
 
-  a.contact-link::before,
-  a.contact-link::after {
-    position: absolute;
-    width: 100%;
-    height: 3px;
-    background: $color-primary;
-    top: 100%;
-    left: 0;
-    pointer-events: none;
-  }
-
-  a.contact-link::before {
-    content: "";
-  }
-
-  a.contact-link {
+  a {
     color: $color-primary;
-    text-decoration: none;
-    position: relative;
-
-    &:hover::before {
-      transform-origin: 0% 50%;
-      transform: scale3d(1, 2, 1);
-      transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
-    }
-
-    &::before {
-      transform-origin: 100% 50%;
-      transform: scale3d(0, 1, 1);
-      transition: transform 0.3s cubic-bezier(0.2, 1, 0.8, 1);
-    }
-
-    &:hover::after {
-      transform-origin: 0% 50%;
-      transform: scale3d(1, 1, 1);
-      transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
-    }
-
-    &::after {
-      content: "";
-      top: calc(100% + 10px);
-      transform-origin: 100% 50%;
-      transform: scale3d(0, 1, 1);
-      transition: transform 0.4s 0.1s cubic-bezier(0.2, 1, 0.8, 1);
-    }
   }
 
   .contact-cards {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -11,7 +11,7 @@ const variants = {
     opacity: 0,
   },
   center: {
-    zIndex: 1,
+    zIndex: 5,
     x: 0,
     opacity: 1,
   },

--- a/src/components/HighlightLink/HighlightLink.scss
+++ b/src/components/HighlightLink/HighlightLink.scss
@@ -3,6 +3,7 @@
 a.highlight {
   position: relative;
   display: inline-block;
+  z-index: -1;
 
   &::before {
     position: absolute;

--- a/src/components/HighlightLink/HighlightLink.scss
+++ b/src/components/HighlightLink/HighlightLink.scss
@@ -14,13 +14,5 @@ a.highlight {
     height: 0.5rem;
     background-color: rgba($color-primary, 0.2);
     content: "";
-    -webkit-transition: -webkit-transform 0.2s;
-    transition: all 0.2s ease-in-out;
-  }
-
-  &:hover::before,
-  a:focus::before {
-    bottom: 0;
-    height: 70%;
   }
 }


### PR DESCRIPTION
Due to weird z-index stuff, I removed the hover styling of the HighlightLink component and gave it a `z-index` of -1 to fix the overlapping issue.

The issue is that, even though the mobile menu had a higher `z-index`, its position was fixed, so the HighlightLink was still overlapping anyways since its position is relative. So in the end, I just removed it. I also changed the email link in the Contact section to be the HighlightLink to fix the issue of that link also overlapping on the mobile menu.