### PR TITLE
Fix mobile menu not on topmost layer

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -13,6 +13,7 @@
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   transition: 0.3s ease all;
+  z-index: 5;
 
   @media screen and (max-width: $breakpoint-desktop) {
     .container {

--- a/src/components/HighlightLink/HighlightLink.scss
+++ b/src/components/HighlightLink/HighlightLink.scss
@@ -3,7 +3,6 @@
 a.highlight {
   position: relative;
   display: inline-block;
-  z-index: -1;
 
   &::before {
     position: absolute;
@@ -14,5 +13,12 @@ a.highlight {
     height: 0.5rem;
     background-color: rgba($color-primary, 0.2);
     content: "";
+    transition: all 0.2s ease-in-out;
+  }
+
+  &:hover::before,
+  a:focus::before {
+    bottom: 0;
+    height: 70%;
   }
 }


### PR DESCRIPTION
Fixed it by adding a z-index on the `.sticky` ancestor class instead of just the actual mobile menu div.

I also brought back the hover styling since it's no longer an issue.